### PR TITLE
Add sponsorship information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
-# about
-Information about the user group
+# About
+
+This repository is used to share information about the PDX Go user group.
+
+👨‍👩‍👧‍👦  [Code of Conduct](https://golang.org/conduct)
+
+***
+💵 [Sponsorship](sponsorship/)

--- a/sponsorship/README.md
+++ b/sponsorship/README.md
@@ -1,0 +1,41 @@
+## 💵 Sponsorship
+
+PDX Go is a volunteer-run organization that seeks to remain as friendly and welcoming as possible to everyone. Therefore membership of PDX Go is 100% free and we do not charge for attending events. Not only that, but we provide food and drink at all of our events! We therefore rely on sponsorship to cover our costs.
+
+### Sponsorship Options
+We have three categories of sponsorship:
+
+* Recurring sponsors. Contribute a fixed amount every month. **We are actively looking for recurring sponsors.**
+* Venue sponsors. Venue sponsors will each host us a few times a year. We are not looking for venue sponsors at this time.
+* Ad-hoc sponsorship. Be it covering food, drinks or venue for the odd meetup, or a donation to cover a specific cost.
+
+### Why Sponsor?
+We have a growing community so sponsoring PDX Go is a great opportunity for your company/brand:
+
+* We have over 800 members in our [Meetup group](https://www.meetup.com/PDX-Go/)
+* Go is a growing language - if you aren't using it now, chances are you might in the future!
+
+By sponsoring, you are helping ensure that the user group continues to be able to hold events and grow in addition to being listed on the [Meetup group Sponsors' page](https://www.meetup.com/PDX-Go/sponsors/).
+
+### Where do we incur costs?
+* Venues 
+* Food - We try to provide enough food for attendees each month and accomodate vegan and dietary restrictions if possible. With about 30-40 attendees each month, it can add up.
+
+Because we operate as a non-profit and volunteer-run organization, any excess funds typically go towards community programs like [GoBridge](https://github.com/gobridge/about-us/blob/master/README.md) We want to have more workshops in order to help make a more inclusive community.
+
+## 👨‍👩‍👦‍👦 Support us
+If your business is about products or services that could improve the overall Meetup experience, and benefit our community, please consider supporting this group by providing us community licenses or access to free merchandise! Great examples of companies which have supported us this way are:
+
+* JetBrains: three free licenses every quarter for our attendees to give away in a raffle
+* Google: for providing Meetup licenses and occasional swag
+
+We're incredibly grateful to everyone who would like to contribute, one way or another, and we'll make sure our friends will know about your kindness!
+
+---
+As mentioned above, the organizers of PDX Go are volunteers. We are always on the lookout for people keen to join our team!
+
+### Contact Us
+
+Please reach out to us if you have any questions or if you'd like to sponsor!
+
+twitter: [@pdxgolang](https://twitter.com/pdxgolang)


### PR DESCRIPTION
After speaking with the folks at [London Gophers](https://github.com/LondonGophers/admin) over the summer it seemed like a good idea to make some of the administrivia transparent. 

This is based (i.e. - graciously copied) from their admin repository and all credit is due to the folks over there who have done a fantastic job in organizing that user group. 